### PR TITLE
Update theme comment for accuracy

### DIFF
--- a/scripts/theme-toggle.js
+++ b/scripts/theme-toggle.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  // Apply default theme based on 7am–7pm window
+  // Apply default theme from 7am to before 7pm
   const now = new Date();
   const hour = now.getHours();
   const defaultMode = (hour >= 7 && hour < 19) ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- clarify that light-mode defaults from 7am to before 7pm in `theme-toggle.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f6dc16b1c832082fb563f37ace1df