### PR TITLE
Fix index layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
 
   <footer data-include="nav/footer.html"></footer>
 
-</body>
 
   <!-- index.html scaffold nav -->
 <nav>


### PR DESCRIPTION
## Summary
- remove redundant closing tag in `index.html`

## Testing
- `grep -n '</body>' *.html`

------
https://chatgpt.com/codex/tasks/task_e_683f6db5f03c8320996f2a2e4cf1dcdf