### PR TITLE
Fix Knight transcript status markup

### DIFF
--- a/knight-block-transcript.html
+++ b/knight-block-transcript.html
@@ -7,7 +7,7 @@ title: Exhibit A-2 — Knight Institute Email Block
 
 <p class="log-date"><strong>Date:</strong> May 31, 2025</p>
 <strong>Recipient:</strong> legal@knightcolumbia.org<br>
-<strong>Status:</strong> Failed — 554 5.4.14 Hop Count Exceeded (Mail Loop Detected)</p>
+<p><strong>Status:</strong> Failed — 554 5.4.14 Hop Count Exceeded (Mail Loop Detected)</p>
 
 <pre class="email-transcript">
 Transcript:


### PR DESCRIPTION
## Summary
- wrap the delivery status line in its own paragraph

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f6d936ec88320b339a45368c6febc