### PR TITLE
Fix invalid script tags in theme-toggle.js

### DIFF
--- a/scripts/theme-toggle.js
+++ b/scripts/theme-toggle.js
@@ -16,17 +16,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
-<script>
-  window.addEventListener("DOMContentLoaded", () => {
-    const includes = document.querySelectorAll("[data-include]");
-    includes.forEach(async (el) => {
-      const file = el.getAttribute("data-include");
-      if (file) {
-        const res = await fetch(file);
-        const html = await res.text();
-        el.innerHTML = html;
-      }
-    });
+window.addEventListener("DOMContentLoaded", () => {
+  const includes = document.querySelectorAll("[data-include]");
+  includes.forEach(async (el) => {
+    const file = el.getAttribute("data-include");
+    if (file) {
+      const res = await fetch(file);
+      const html = await res.text();
+      el.innerHTML = html;
+    }
   });
-</script>
+});
 


### PR DESCRIPTION
## Summary
- clean up `scripts/theme-toggle.js` by removing stray `<script>` tags
- ensure DOM loader remains functional

## Testing
- `node --check scripts/theme-toggle.js`


------
https://chatgpt.com/codex/tasks/task_e_683f6b3ad79883208eb4d8b3e0f2461c